### PR TITLE
Updating profile_page_metrics and discover_posts in scrapy.py

### DIFF
--- a/scripts/scrap.py
+++ b/scripts/scrap.py
@@ -2,7 +2,7 @@ import json
 import requests
 from bs4 import BeautifulSoup
 from pprint import pprint
-from proxychange import ProxyChanger
+#from proxychange import ProxyChanger
 import time
 
 
@@ -113,14 +113,20 @@ class InstagramScraper(object):
 
     def profile_page_metrics(self, json_data_from_profile):
         results = {}
-        metrics = json_data_from_profile['entry_data']['ProfilePage'][0]['graphql']['user']
-        for key, value in metrics.items():
-            if key != 'edge_owner_to_timeline_media':
-                if value and isinstance(value, dict):
-                    value = value['count']
-                    results[key] = value
-                elif value:
-                    results[key] = value
+        try:
+            metrics = json_data_from_profile['entry_data']['ProfilePage'][0]['graphql']['user']
+            for key, value in metrics.items():
+                if key != 'edge_owner_to_timeline_media':
+                    if value and isinstance(value, dict):
+                        try:
+                            value = value['count']
+                            results[key] = value
+                        except:
+                            continue
+                    elif value:
+                        results[key] = value
+        except:
+            results['error'] = 'No profile data found for user'
         return results
 
     def profile_page_recent_posts(self, json_data_from_profile):
@@ -142,8 +148,10 @@ class InstagramScraper(object):
             json_data = self.extract_json_data(response)
             metrics = json_data['entry_data']['TagPage'][0]['graphql']['hashtag']['edge_hashtag_to_top_posts'][
                 "edges"]
-        except Exception as e:
-            raise e
+        except:
+            pass
+          
+            
         else:
             for node in metrics:
                 node = node.get('node')


### PR DESCRIPTION
Added a try/except statement to previously line 120 (value=value['count']. This creates an error when there is no ['ProfilePage'] data. The try/except also added a statement of error that no profile data was found.

Then gave the following issue:
[DISCOVER BOT] Account exists.
Traceback (most recent call last):
  File "discover_script.py", line 93, in <module>
    bot.start_bot()
  File "discover_script.py", line 34, in start_bot
    self.discover_new_accounts_through_hashtags(hashtags, category)
  File "discover_script.py", line 75, in discover_new_accounts_through_hashtags
    accounts = self.scraper.discover_accounts_from_hashtag(hashtag)
  File "G:\OneDrive\Academia\Acies-Digital\Web Apps\Testing\Instagram\Jakobowsky\InfluencerDB-YouTube\scripts\scrap.py", line 170, in discover_accounts_from_hashtag
    posts_ids = self.discover_posts(hashtag)
  File "G:\OneDrive\Academia\Acies-Digital\Web Apps\Testing\Instagram\Jakobowsky\InfluencerDB-YouTube\scripts\scrap.py", line 152, in discover_posts
    raise e
  File "G:\OneDrive\Academia\Acies-Digital\Web Apps\Testing\Instagram\Jakobowsky\InfluencerDB-YouTube\scripts\scrap.py", line 149, in discover_posts
    metrics = json_data['entry_data']['TagPage'][0]['graphql']['hashtag']['edge_hashtag_to_top_posts'][
KeyError: 'TagPage'

Then removed raise exception and added a pass to the code due to empty or erroneous accounts info.

It makes it slightly less robust, but it prevents the breaks happening that we have been seeing