### PR TITLE
Updating scrap.py __get_connected_hashtags

### DIFF
--- a/scripts/scrap.py
+++ b/scripts/scrap.py
@@ -183,7 +183,7 @@ class InstagramScraper(object):
             metrics = json_data['entry_data']['TagPage'][0]['graphql']['hashtag']['edge_hashtag_to_related_tags'][
                 "edges"]
         except Exception as e:
-            raise e
+            print (f'Error found: {e}')
         else:
             for node in metrics:
                 node = node.get('node')


### PR DESCRIPTION
The function __get_connected_hashtags was breaking the running of the app, rather than printing the exception and continuing. 

I have changed the line to now print the error so the script can continue.